### PR TITLE
feat: DB락에서 redis 분산락으로 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.17.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/palgona/palgona/bidding/application/BiddingService.java
+++ b/src/main/java/com/palgona/palgona/bidding/application/BiddingService.java
@@ -3,16 +3,15 @@ package com.palgona.palgona.bidding.application;
 import static com.palgona.palgona.common.error.code.BiddingErrorCode.BIDDING_EXPIRED_PRODUCT;
 import static com.palgona.palgona.common.error.code.BiddingErrorCode.BIDDING_INSUFFICIENT_BID;
 import static com.palgona.palgona.common.error.code.BiddingErrorCode.BIDDING_LOWER_PRICE;
-import static com.palgona.palgona.common.error.code.MemberErrorCode.MEMBER_NOT_FOUND;
 import static com.palgona.palgona.common.error.code.ProductErrorCode.NOT_FOUND;
 
+import com.palgona.palgona.common.annotation.DistributedLock;
 import com.palgona.palgona.common.error.exception.BusinessException;
 import com.palgona.palgona.bidding.domain.Bidding;
 import com.palgona.palgona.bidding.domain.BiddingState;
 import com.palgona.palgona.member.domain.Member;
 import com.palgona.palgona.product.domain.Product;
 import com.palgona.palgona.purchase.domain.Purchase;
-import com.palgona.palgona.bidding.dto.request.BiddingAttemptRequest;
 import com.palgona.palgona.bidding.domain.BiddingRepository;
 import com.palgona.palgona.purchase.infrastructure.PurchaseRepository;
 import com.palgona.palgona.member.domain.MemberRepository;
@@ -35,47 +34,59 @@ public class BiddingService {
     private final PurchaseRepository purchaseRepository;
     private final MemberRepository memberRepository;
 
-    @Transactional
-    public void attemptBidding(Member member, BiddingAttemptRequest request) {
-        Product product = findProductWithPessimisticLock(request);
+    @DistributedLock(key = "#productId")
+    public void attemptBidding(Long productId, Member biddingMember, int attemptPrice) {
+        Product product = findProductWithPessimisticLock(productId);
 
-        int attemptPrice = request.price();
+        validateProductDeadline(product);
+        validateBiddingCreate(attemptPrice, product);
 
-        if (product.isDeadlineReached()) {
-            throw new BusinessException(BIDDING_EXPIRED_PRODUCT);
-        }
+        int previousBid = biddingRepository.findHighestPriceByMember(biddingMember).orElse(0);
+        int extraCost = attemptPrice - previousBid;
+        biddingMember.useMileage(extraCost);
+        Bidding bidding = Bidding.builder()
+                .member(biddingMember)
+                .product(product)
+                .price(attemptPrice)
+                .build();
 
+        biddingRepository.save(bidding);
+        memberRepository.save(biddingMember);
+    }
+
+    private void validateBiddingCreate(int attemptPrice, Product product) {
         int highestPrice = biddingRepository.findHighestPriceByProduct(product).orElse(0);
+        int threshold = (int) Math.pow(10, String.valueOf(attemptPrice).length() - 2);
+        int priceDifference = attemptPrice -  highestPrice;
+
+        if (attemptPrice < product.getInitialPrice()) {
+            throw new BusinessException(BIDDING_LOWER_PRICE);
+        }
 
         if (attemptPrice <= highestPrice) {
             throw new BusinessException(BIDDING_LOWER_PRICE);
         }
 
-        int threshold = (int) Math.pow(10, String.valueOf(attemptPrice).length() - 2);
-        int priceDifference = attemptPrice - highestPrice;
-
         if (priceDifference < threshold) {
             throw new BusinessException(BIDDING_INSUFFICIENT_BID);
         }
-
-        Member biddingMember = findMemberWithPessimisticLock(member);
-        int previousBid = biddingRepository.findHighestPriceByMember(biddingMember).orElse(0);
-        int extraCost = attemptPrice - previousBid;
-        biddingMember.useMileage(extraCost);
-        Bidding bidding = Bidding.builder().member(biddingMember).product(product).price(attemptPrice).build();
-
-        biddingRepository.save(bidding);
     }
 
-    private Product findProductWithPessimisticLock(BiddingAttemptRequest request) {
-        return productRepository.findByIdWithPessimisticLock(request.productId())
+    private void validateProductDeadline(Product product) {
+        if (product.isDeadlineReached()) {
+            throw new BusinessException(BIDDING_EXPIRED_PRODUCT);
+        }
+    }
+
+    private Product findProductWithPessimisticLock(Long id) {
+        return productRepository.findByIdWithPessimisticLock(id)
                 .orElseThrow(() -> new BusinessException(NOT_FOUND));
 
     }
 
     public Page<Bidding> findAllByProductId(long productId, Pageable pageable) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 product가 없습니다."));
+                .orElseThrow(() -> new BusinessException(NOT_FOUND));
 
         return biddingRepository.findAllByProduct(pageable, product);
     }
@@ -129,10 +140,5 @@ public class BiddingService {
                 }
             }
         }
-    }
-
-    private Member findMemberWithPessimisticLock(Member member) {
-        return memberRepository.findByIdWithPessimisticLock(member.getId())
-                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/palgona/palgona/bidding/domain/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/bidding/domain/BiddingRepository.java
@@ -24,9 +24,19 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
     List<Bidding> findExpiredBiddingsWithPessimisticLock(@Param("currentDateTime") LocalDateTime currentDateTime);
     boolean existsByProduct(Product product);
 
+    @Query("""
+        SELECT MAX(b.price)
+        FROM Bidding b
+        WHERE b.product = :product
+        """)
     Optional<Integer> findHighestPriceByProduct(Product product);
 
     boolean existsByMember(Member member);
 
+    @Query("""
+       SELECT MAX(b.price)
+       FROM Bidding b
+       WHERE b.member = :member
+       """)
     Optional<Integer> findHighestPriceByMember(Member member);
 }

--- a/src/main/java/com/palgona/palgona/bidding/presentation/BiddingController.java
+++ b/src/main/java/com/palgona/palgona/bidding/presentation/BiddingController.java
@@ -28,9 +28,15 @@ public class BiddingController {
 
     @PostMapping(value = "/attempt", consumes = {MediaType.APPLICATION_JSON_VALUE})
     @Operation(summary = "입찰 진행 api", description = "물건 id와 가격을 받아서 입찰을 진행한다.")
-    public ResponseEntity<Void> attemptBidding(@AuthenticationPrincipal CustomMemberDetails member,
-                                               @RequestBody BiddingAttemptRequest request) {
-        biddingService.attemptBidding(member.getMember(), request);
+    public ResponseEntity<Void> attemptBidding(
+            @AuthenticationPrincipal CustomMemberDetails loginMember,
+            @RequestBody BiddingAttemptRequest request
+    ) {
+        biddingService.attemptBidding(
+                request.productId(),
+                loginMember.getMember(),
+                request.price()
+        );
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/palgona/palgona/common/annotation/DistributedLock.java
+++ b/src/main/java/com/palgona/palgona/common/annotation/DistributedLock.java
@@ -1,0 +1,20 @@
+package com.palgona.palgona.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/palgona/palgona/common/aop/DistributedLockAop.java
+++ b/src/main/java/com/palgona/palgona/common/aop/DistributedLockAop.java
@@ -1,0 +1,60 @@
+package com.palgona.palgona.common.aop;
+
+import com.palgona.palgona.common.annotation.DistributedLock;
+import com.palgona.palgona.common.util.CustomSpringELParser;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final LockTransaction lockTransaction;
+
+    @Around("@annotation(com.palgona.palgona.common.annotation.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                distributedLock.key()
+        );
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(
+                    distributedLock.waitTime(),
+                    distributedLock.leaseTime(),
+                    distributedLock.timeUnit()
+            );
+            if (!available) {
+                return false;
+            }
+
+            return lockTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.info("Lock already unlock {} {}", method.getName(), key);
+            }
+        }
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/aop/LockTransaction.java
+++ b/src/main/java/com/palgona/palgona/common/aop/LockTransaction.java
@@ -1,0 +1,15 @@
+package com.palgona.palgona.common.aop;
+
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LockTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/palgona/palgona/common/util/CustomSpringELParser.java
+++ b/src/main/java/com/palgona/palgona/common/util/CustomSpringELParser.java
@@ -1,0 +1,24 @@
+package com.palgona.palgona.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+@Slf4j
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            log.info("parameterName[i], args[i] : {} {}", parameterNames[i], args[i]);
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/palgona/palgona/config/RedisConfig.java
+++ b/src/main/java/com/palgona/palgona/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.palgona.palgona.config;
 
 import com.palgona.palgona.common.WebSocket.RedisChatSubscriber;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +18,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
 
     @Value("${spring.data.redis.host}")
     private String host;
@@ -64,5 +69,14 @@ public class RedisConfig {
     @Bean
     public ChannelTopic channelTopic() {
         return new ChannelTopic("chatroom");
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        redisson = Redisson.create(config);
+        return redisson;
     }
 }

--- a/src/main/java/com/palgona/palgona/product/application/ProductService.java
+++ b/src/main/java/com/palgona/palgona/product/application/ProductService.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -113,7 +114,13 @@ public class ProductService {
                                                            String cursor,
                                                            int pageSize
     ) {
-        return productRepository.findAllByCategoryAndSearchWord(category, searchWord, cursor, sortType, pageSize);
+        return productRepository.findAllByCategoryAndSearchWord(
+                category,
+                searchWord,
+                cursor,
+                sortType,
+                pageSize
+        );
     }
 
     @Transactional

--- a/src/main/java/com/palgona/palgona/product/domain/Product.java
+++ b/src/main/java/com/palgona/palgona/product/domain/Product.java
@@ -114,8 +114,7 @@ public class Product extends BaseTimeEntity {
     public void updateProductState(ProductState productState) {this.productState = productState;}
 
     public boolean isDeadlineReached() {
-        LocalDateTime currentDateTime = LocalDateTime.now();
-        return currentDateTime.isAfter(this.deadline);
+        return LocalDateTime.now().isAfter(this.deadline);
     }
 
     public boolean isOwner(Member member){


### PR DESCRIPTION
## Issue
resolve #1 

## Change
* 기존에는 db락을 통해서 입찰 동시성을 처리했었는데 이를 redis의 분산락으로 처리되도록 변경했습니다.
* rdb에 가던 부하를 redis에 나눠가지게 하는 것이 목적입니다. 채팅 브로커로서 redis를 이미 인프라에 구축해두었기 때문에 추가적인 인프라 설정 비용은 없다고 가정했습니다.

## etc
* 락의 범위를 TX 범위보다 넓게 설정함으로써 추가적으로 발생할 수 있는 갱신 분실 문제를 방지했습니다.
* 분산락 처리 Aop에서 Lock을 획득하고 TX를 시작하도록 구현했습니다.
<img width="809" alt="ttt" src="https://github.com/user-attachments/assets/86f662e6-d594-4849-b19d-c83309918c3e">
