### PR TITLE
refactor: 마일리지 변경시에 발생하는 동시성 처리 수정

### DIFF
--- a/src/main/java/com/palgona/palgona/bidding/application/BiddingService.java
+++ b/src/main/java/com/palgona/palgona/bidding/application/BiddingService.java
@@ -70,9 +70,14 @@ public class BiddingService {
             expiredProduct.sell();
             Bidding latestBidding = biddings.get(0);
             latestBidding.success();
-            Purchase purchase = Purchase.of(latestBidding.getPrice(), latestBidding, latestBidding.getMember());
-            purchaseRepository.save(purchase);
+            Purchase purchase = Purchase.of(
+                    latestBidding.getPrice(),
+                    latestBidding,
+                    latestBidding.getMember(),
+                    expiredProduct.getMember()
+            );
 
+            purchaseRepository.save(purchase);
 
             for (int i = 1; i < biddings.size(); i++) {
                 Bidding failedBidding = biddings.get(i);

--- a/src/main/java/com/palgona/palgona/bidding/domain/Bidding.java
+++ b/src/main/java/com/palgona/palgona/bidding/domain/Bidding.java
@@ -60,4 +60,9 @@ public class Bidding extends BaseTimeEntity {
     public void fail() {
         state = BiddingState.FAILED;
     }
+
+    public void cancel() {
+        state = BiddingState.CANCEL;
+    }
+
 }

--- a/src/main/java/com/palgona/palgona/bidding/domain/BiddingRepository.java
+++ b/src/main/java/com/palgona/palgona/bidding/domain/BiddingRepository.java
@@ -17,13 +17,6 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
     Page<Bidding> findAllByProduct(Pageable pageable, Product product);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT b FROM Bidding b "
-            + "JOIN FETCH b.member m "
-            + "WHERE b.state = 'ATTEMPT' AND b.product.deadline <= :currentDateTime")
-    List<Bidding> findExpiredBiddingsWithPessimisticLock(@Param("currentDateTime") LocalDateTime currentDateTime);
-    boolean existsByProduct(Product product);
-
     @Query("""
         SELECT MAX(b.price)
         FROM Bidding b
@@ -31,7 +24,7 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
         """)
     Optional<Integer> findHighestPriceByProduct(Product product);
 
-    boolean existsByMember(Member member);
+    boolean existsByProduct(Product product);
 
     @Query("""
        SELECT MAX(b.price)

--- a/src/main/java/com/palgona/palgona/bidding/domain/BiddingState.java
+++ b/src/main/java/com/palgona/palgona/bidding/domain/BiddingState.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum BiddingState {
     SUCCESS("SUCCESS", "성공"),
     FAILED("FAILED", "실패"),
-    ATTEMPT("ATTEMPT", "시도");
+    ATTEMPT("ATTEMPT", "시도"),
+    CANCEL("CANCEL", "취소");
 
     private final String key;
     private final String title;

--- a/src/main/java/com/palgona/palgona/common/error/code/PurchaseErrorCode.java
+++ b/src/main/java/com/palgona/palgona/common/error/code/PurchaseErrorCode.java
@@ -10,7 +10,8 @@ public enum PurchaseErrorCode implements ErrorCode{
 
     PURCHASE_NOT_FOUND(HttpStatus.OK, "PC_001", "구매 기록을 찾을 수 없습니다."),
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "PC_002", "구매 기록에 대한 권한이 없습니다."),
-    PURCHASE_EXPIRED(HttpStatus.BAD_REQUEST, "PC_003", "이미 구매 확정 기간이 지났습니다.");
+    PURCHASE_EXPIRED(HttpStatus.BAD_REQUEST, "PC_003", "이미 구매 확정 기간이 지났습니다."),
+    PURCHASE_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PC_004", "구매 확정을 취소할 수 없는 상태입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/palgona/palgona/purchase/infrastructure/PurchaseRepositoryImpl.java
+++ b/src/main/java/com/palgona/palgona/purchase/infrastructure/PurchaseRepositoryImpl.java
@@ -41,7 +41,7 @@ public class PurchaseRepositoryImpl implements PurchaseRepositoryCustom {
                 .from(purchase)
                 .innerJoin(purchase.bidding, bidding)
                 .innerJoin(bidding.product, product)
-                .where(purchase.member.eq(member),
+                .where(purchase.buyer.eq(member),
                         ltPurchaseId(cursor))
                 .orderBy(purchase.id.desc())
                 .limit(pageSize + 1)


### PR DESCRIPTION
## Issue
#5 

## Change
* 기존에는 Purchase를 가져올 때, buyer를 fetch join 해서 가져오고 SELECT FOR UPDATE를 붙여서 가져왔다. 하지만 Member에는 락이 제대로 걸리지 않고 있었다.. 때문에 purchase와 member는 각각 조회하고 동시성 제어가 필요한 member에 대해서만 쓰기락을 걸었다.
<img width="725" alt="2024-09-14_15-01-58" src="https://github.com/user-attachments/assets/8249ed72-44d4-412d-9a4a-3b2fcfdff1bb">

* 구매 확정 기간이 지난 구매 기록에 대한 취소 로직을 수정했다.
* 쿼리 도중에 bulkUpdate가 존재했고 Modify clear를 통해서 영속성 컨택스트를 날렸었는데 이 때문에 구매자의 돈이 정상적으로 환불되지 않고 누락되는 문제를 해결했다. 
<img width="801" alt="2024-09-14_15-04-13" src="https://github.com/user-attachments/assets/d192e143-411b-4a88-8110-9b9f5f424d44">

* 변경하고 바로 saveAndFlush()를 호출하여 변경 사항을 즉시 DB에 반영하도록 함으로써 영속성 컨택스트가 날아가도 DB에 변경값이 반영되도록 했다.

## etc
* 수정 과정에서 버그를 발견했다.
* 기존 최고 입찰자가 또 다시 중복해서 입찰을 시도할 수 있다.
* 이 문제는 다음 Issue에서 처리한다.